### PR TITLE
Not run next job to prevent max execution time exceeded

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ Since this package extends laravel's `WorkCommand`, it takes exactly all the arg
 
 - `--sansdaemon` option tell the worker to process jobs on the queue without running in daemon mode.
 - `--jobs` (default: 0, optional) - It allows you to specify the number of jobs to process each time the command runs. The default value `0` means it'll process all available jobs in the queue.
+- `--max_exec_time` (default: `ini_get('max_execution_time') - 5s`, optional) - On some webhostings your scripts will be killed, if exceed some amount of time. To prevent this behavior on really full queue, worker will stop after `--max_exec_time`.
+**Note**: `0`(zero) means run forever. This is automatical if run from CLI.
+**Note2**: This will not prevent max time exceeded error. Just will not run next job, if script is reaching its limits.
 
 ## Testing
 // TODO

--- a/README.md
+++ b/README.md
@@ -32,9 +32,11 @@ Since this package extends laravel's `WorkCommand`, it takes exactly all the arg
 
 - `--sansdaemon` option tell the worker to process jobs on the queue without running in daemon mode.
 - `--jobs` (default: 0, optional) - It allows you to specify the number of jobs to process each time the command runs. The default value `0` means it'll process all available jobs in the queue.
-- `--max_exec_time` (default: `ini_get('max_execution_time') - 5s`, optional) - On some webhostings your scripts will be killed, if exceed some amount of time. To prevent this behavior on really full queue, worker will stop after `--max_exec_time`.
-**Note**: `0`(zero) means run forever. This is automatical if run from CLI.
-**Note2**: This will not prevent max time exceeded error. Just will not run next job, if script is reaching its limits.
+- `--max_exec_time` (default: `ini_get('max_execution_time') - 5s`, optional) - On some webhosts, your scripts will be killed, if it exceeds some amount of time. To prevent this behavior on really full queue, worker will stop after `--max_exec_time`. This is especially useful if you're running this command via your application's route or controller. See [Laravel Documentation](https://laravel.com/docs/5.6/artisan#programmatically-executing-commands) on how to run your queue programmatically.
+
+#### Note on `--max_exec_time`
+- `0` (zero) means the worker will run forever, which in this context means until the worker process is done. This is the default behavior  when run from CLI.
+- This option will not prevent `Maximum execution time exceeded` error, it'll try to avoid it by not running the next job on the queue if the script is reaching its [max_execution_time](http://php.net/manual/en/info.configuration.php#ini.max-execution-time)
 
 ## Testing
 // TODO

--- a/src/Console/WorkCommand.php
+++ b/src/Console/WorkCommand.php
@@ -20,9 +20,19 @@ class WorkCommand extends BaseWorkCommand
      */
     public function __construct(Worker $worker)
     {
+        // Constant added in Laravel 5.5
+        if (!defined('LARAVEL_START')) {
+            define('LARAVEL_START', microtime(true));
+        }
+
+        // Get default max execution time - 5s
+        $maxExecutionTime = ini_get('max_execution_time');
+        $maxExecutionTime = $maxExecutionTime <= 0 ? 0 : $maxExecutionTime - 5;
+
         $this->signature .= '{--sansdaemon : Run the worker without a daemon}
-                             {--jobs=0 : Number of jobs to process before worker exits}';
-                    
+                             {--jobs=0 : Number of jobs to process before worker exits}
+                             {--max_exec_time='.$maxExecutionTime.' : Maximum seconds to run to prevent error (0 - forever)}';
+
         $this->description .= ' or sans-daemon';
 
         parent::__construct($worker);
@@ -55,7 +65,8 @@ class WorkCommand extends BaseWorkCommand
     {
         $options = parent::gatherWorkerOptions();
         $options->jobs = $this->option('jobs');
-        
+        $options->maxExecutionTime = intval($this->option('max_exec_time'));
+
         return $options;
     }
 }

--- a/src/Traits/SansDaemonWorkerTrait.php
+++ b/src/Traits/SansDaemonWorkerTrait.php
@@ -59,6 +59,7 @@ trait SansDaemonWorkerTrait
         if ($this->isOverMaxExecutionTime($options)) {
             return false;
         }
+
         if ($options->jobs) {
             return $this->getSize($connectionName, $queue) != 0
                     && $this->jobsProcessed != (int) $options->jobs;
@@ -70,15 +71,16 @@ trait SansDaemonWorkerTrait
     /**
      * Check if worker is running longer, than set max execution time
      *
-     * @param  \Illuminate\Queue\WorkerOptions
+     * @param  \Illuminate\Queue\WorkerOptions  $options
      * @return bool
      */
     protected function isOverMaxExecutionTime($options)
     {
-        // Is set 0 or less -> worker can run forever
+        //Is set 0 or less -> worker can run forever
         if ($options->maxExecutionTime <= 0) {
             return false;
         }
+
         $elapsedTime = microtime(true) - LARAVEL_START;
         return $elapsedTime > $options->maxExecutionTime;
     }


### PR DESCRIPTION
See #3 :

To prevent `Maximum execution time of XX seconds exceeded` error, I added new option `--max_exec_time` which is automatically set to `ini_get('max_execution_time') ` - 5 seconds. If scripts reach this limit, next job will not be run. Of course, if there is no limit, it set automatically 0, which means run forever.