### PR TITLE
Add gitattributes to don't install extra files with composer

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+/tests export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.styleci.yml export-ignore
+.travis.yml export-ignore
+phpunit.xml.dist export-ignore


### PR DESCRIPTION
All files and folder listed in `.gitattributes` file marked as *export-ignore* will not be downloaded via `composer install` command, so the vendor folder of user will be more clean.

It is suggested to use this file as rule no. 10 https://thephpleague.com/#quality