### PR TITLE
Add support for Laravel 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     }],
     "require": {
         "php": "^7.2|^8.0",
-        "illuminate/support": "^6.0|^7.0|^8.0"
+        "illuminate/support": "^6.0|^7.0|^8.0|^9.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8",


### PR DESCRIPTION
Laravel 9 requires

illuminate/support ^9.0
php ^8.0

Updated the composer.json file