### PR TITLE
Fix registering command in Laravel 9

### DIFF
--- a/src/SansDaemonServiceProvider.php
+++ b/src/SansDaemonServiceProvider.php
@@ -4,9 +4,9 @@ namespace Queueworker\SansDaemon;
 
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Queue\Console\WorkCommand as QueueWorkCommand;
 use Illuminate\Queue\QueueServiceProvider;
 use Queueworker\SansDaemon\Console\WorkCommand;
-use Illuminate\Queue\Console\WorkCommand as QueueWorkCommand;
 
 class SansDaemonServiceProvider extends QueueServiceProvider
 {
@@ -56,7 +56,7 @@ class SansDaemonServiceProvider extends QueueServiceProvider
      */
     protected function registerWorkCommand()
     {
-        if (version_compare($this->app->version(), "9.0.0", ">=")) {
+        if (version_compare($this->app->version(), '9.0.0', '>=')) {
             $this->app->extend(QueueWorkCommand::class, function ($command, Application $app) {
                 return new WorkCommand($app['queue.sansDaemonWorker'], $app['cache.store']);
             });

--- a/src/SansDaemonServiceProvider.php
+++ b/src/SansDaemonServiceProvider.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Queue\QueueServiceProvider;
 use Queueworker\SansDaemon\Console\WorkCommand;
+use Illuminate\Queue\Console\WorkCommand as QueueWorkCommand;
 
 class SansDaemonServiceProvider extends QueueServiceProvider
 {
@@ -55,8 +56,14 @@ class SansDaemonServiceProvider extends QueueServiceProvider
      */
     protected function registerWorkCommand()
     {
-        $this->app->extend('command.queue.work', function ($command, Application $app) {
-            return new WorkCommand($app['queue.sansDaemonWorker'], $app['cache.store']);
-        });
+        if (version_compare($this->app->version(), "9.0.0", ">=")) {
+            $this->app->extend(QueueWorkCommand::class, function ($command, Application $app) {
+                return new WorkCommand($app['queue.sansDaemonWorker'], $app['cache.store']);
+            });
+        } else {
+            $this->app->extend('command.queue.work', function ($command, Application $app) {
+                return new WorkCommand($app['queue.sansDaemonWorker'], $app['cache.store']);
+            });
+        }
     }
 }

--- a/src/SansDaemonServiceProvider.php
+++ b/src/SansDaemonServiceProvider.php
@@ -4,7 +4,7 @@ namespace Queueworker\SansDaemon;
 
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Foundation\Application;
-use Illuminate\Queue\Console\WorkCommand as QueueWorkCommand;
+use Illuminate\Queue\Console\WorkCommand as BaseWorkCommand;
 use Illuminate\Queue\QueueServiceProvider;
 use Queueworker\SansDaemon\Console\WorkCommand;
 
@@ -57,7 +57,7 @@ class SansDaemonServiceProvider extends QueueServiceProvider
     protected function registerWorkCommand()
     {
         if (version_compare($this->app->version(), '9.0.0', '>=')) {
-            $this->app->extend(QueueWorkCommand::class, function ($command, Application $app) {
+            $this->app->extend(BaseWorkCommand::class, function ($command, Application $app) {
                 return new WorkCommand($app['queue.sansDaemonWorker'], $app['cache.store']);
             });
         } else {

--- a/src/SansDaemonServiceProvider.php
+++ b/src/SansDaemonServiceProvider.php
@@ -4,9 +4,9 @@ namespace Queueworker\SansDaemon;
 
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Queue\Console\WorkCommand as BaseWorkCommand;
 use Illuminate\Queue\QueueServiceProvider;
 use Queueworker\SansDaemon\Console\WorkCommand;
-use Illuminate\Queue\Console\WorkCommand as BaseWorkCommand;
 
 class SansDaemonServiceProvider extends QueueServiceProvider
 {

--- a/src/SansDaemonServiceProvider.php
+++ b/src/SansDaemonServiceProvider.php
@@ -4,12 +4,22 @@ namespace Queueworker\SansDaemon;
 
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Foundation\Application;
-use Illuminate\Queue\Console\WorkCommand as BaseWorkCommand;
 use Illuminate\Queue\QueueServiceProvider;
 use Queueworker\SansDaemon\Console\WorkCommand;
+use Illuminate\Queue\Console\WorkCommand as BaseWorkCommand;
 
 class SansDaemonServiceProvider extends QueueServiceProvider
 {
+    /**
+     * List of supported base commands.
+     *
+     * @var array
+     */
+    protected $supportedBaseCommands = [
+        BaseWorkCommand::class,
+        'command.queue.work',
+    ];
+
     /**
      * Register the application services.
      *
@@ -56,14 +66,16 @@ class SansDaemonServiceProvider extends QueueServiceProvider
      */
     protected function registerWorkCommand()
     {
-        if (version_compare($this->app->version(), '9.0.0', '>=')) {
-            $this->app->extend(BaseWorkCommand::class, function ($command, Application $app) {
-                return new WorkCommand($app['queue.sansDaemonWorker'], $app['cache.store']);
-            });
-        } else {
-            $this->app->extend('command.queue.work', function ($command, Application $app) {
-                return new WorkCommand($app['queue.sansDaemonWorker'], $app['cache.store']);
-            });
+        // We'll go through the list of known supported queue commands and
+        // extend them if they've been bound to the container.
+        foreach ($this->supportedBaseCommands as $baseCommand) {
+            if ($this->app->bound($baseCommand)) {
+                $this->app->extend($baseCommand, function ($command, Application $app) {
+                    return new WorkCommand($app['queue.sansDaemonWorker'], $app['cache.store']);
+                });
+
+                break;
+            }
         }
     }
 }


### PR DESCRIPTION
Check difference between:
- Laravel 9+ - https://github.com/laravel/framework/blob/9.x/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php#L123
- Laravel prior 9 - https://github.com/laravel/framework/blob/8.x/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php#L122

So it does not work now at Laravel 9